### PR TITLE
Fix for Xamarin 4.0

### DIFF
--- a/TouchEffect.Droid/PlatformTouchEff.cs
+++ b/TouchEffect.Droid/PlatformTouchEff.cs
@@ -29,6 +29,11 @@ namespace TouchEffect.Android
             {
                 Container.Touch += OnTouch;
             }
+            else if (Control != null)
+            {
+                Control.Touch += OnTouch;
+            }
+
         }
 
         protected override void OnDetached()
@@ -39,6 +44,11 @@ namespace TouchEffect.Android
             {
                 Container.Touch -= OnTouch;
             }
+            if (Control != null)
+            {
+                Control.Touch -= OnTouch;
+            }
+
         }
 
         private void OnTouch(object sender, AView.TouchEventArgs e)


### PR DESCRIPTION
On Xamarin 4 the Container property is null. I added a fallback to the property Control if that is the case.