### PR TITLE
(Urgent) Fix UWP PointerRelease always Cancelling Touch

### DIFF
--- a/TouchEffect.UWP/PlatformTouchEff.cs
+++ b/TouchEffect.UWP/PlatformTouchEff.cs
@@ -82,7 +82,6 @@ namespace TouchEffect.UWP
 
         private void OnPointerReleased(object sender, PointerRoutedEventArgs e)
         {
-            _pressed = false;
             if (_pressed && _inrange)
             {
                 Element.GetTouchEff().HandleTouch(TouchStatus.Completed);
@@ -91,6 +90,7 @@ namespace TouchEffect.UWP
             {
                 Element.GetTouchEff().HandleTouch(TouchStatus.Canceled);
             }
+            _pressed = false;
         }
 
         private void OnPointerPressed(object sender, PointerRoutedEventArgs e)


### PR DESCRIPTION
This is a small and quick but urgent fix for a small bug that slipped in: `_pressed` was set to false, which caused any pointer release to result in `TouchStatus.Cancelled`.